### PR TITLE
Use custom folders to avoid locking, reject if certbot instance is already running

### DIFF
--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -9,7 +9,7 @@ import { agent, SuperAgentTest } from "supertest";
 import { promisify } from "util";
 import { app } from "../src/app";
 import config from "../src/config";
-import { createIfNotExists, prepareMessageFromPackage } from "../src/utils";
+import { prepareMessageFromPackage } from "../src/utils";
 
 describe("app", () => {
   let request: SuperAgentTest;
@@ -70,7 +70,7 @@ describe("app", () => {
     const domain: string = `${id}.dyndns.dappnode.io`;
 
     const certDir: string = path.resolve(__dirname, "certs");
-    createIfNotExists(certDir);
+    fs.mkdirSync(certDir, { recursive: true });
 
     await promisify(csrgen)(domain, {
       outputDir: certDir,


### PR DESCRIPTION
Regarding https://github.com/Shard-Labs/dappnode-cert-api/issues/3